### PR TITLE
add initial value arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Opens a new or an already existing semaphore with `sem_open`. Fails with an erro
   - `debug` : Prints useful information. Default : false
   - `silent` : Some information is printed with `closeOnExit`=true and when native calls fail. Allows you to disable that behavior. Default : false
   - `retryOnEintr` : If `sem_wait` fails with `EINTR` (usually it's due to a SIGINT signal being fired on CTRL-C), try to acquire the lock again. Default : false
+  - `value` : Initial value of semaphore. Default : 1
 
 #### `sem.acquire()`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posix-semaphore",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Blocking POSIX semaphores for Node.js",
   "repository": "https://github.com/dbousque/posix-semaphore",
   "license": "MIT",

--- a/srcs/addon.js
+++ b/srcs/addon.js
@@ -74,7 +74,7 @@ function Semaphore(name, options) {
   semaphoreNames[name] = 1
   this.name = name
   options = parseOptions(options)
-  this.sem = new SemaphoreCPP(name, options.strict, options.debug, options.silent, options.retryOnEintr)
+  this.sem = new SemaphoreCPP(name, options.strict, options.debug, options.silent, options.retryOnEintr, options.value)
   if (options.closeOnExit === undefined || options.closeOnExit) {
     const onExit = () => {
       if (this.closed !== true) {

--- a/srcs/semaphore.h
+++ b/srcs/semaphore.h
@@ -11,7 +11,7 @@ class Semaphore : public Nan::ObjectWrap {
   static void Init(v8::Local<v8::Object> exports);
 
  private:
-  explicit Semaphore(char *buf, size_t buf_len, bool strict, bool debug, bool silent, bool retry_on_eintr);
+  explicit Semaphore(char *buf, size_t buf_len, bool strict, bool debug, bool silent, bool retry_on_eintr, unsigned int value = 1);
   ~Semaphore();
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);


### PR DESCRIPTION
Added optional arg for initial value of semaphore (defaults to 1 for backwards compatibility).  This allows additional IPC use cases.